### PR TITLE
Update packet_flow_key.py

### DIFF
--- a/meter/features/context/packet_flow_key.py
+++ b/meter/features/context/packet_flow_key.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-from meter.features.context import packet_direction
+from meter.features.context.packet_direction import PacketDirection
 
 
 def get_packet_flow_key(packet, direction) -> tuple:
@@ -30,7 +30,7 @@ def get_packet_flow_key(packet, direction) -> tuple:
     else:
         raise Exception('Only TCP protocols are supported.')
 
-    if direction == packet_direction.FORWARD:
+    if direction == PacketDirection.FORWARD:
         dest_ip = packet['IP'].dst
         src_ip = packet['IP'].src
         src_port = packet[protocol].sport


### PR DESCRIPTION
there is an issue here in the import, the original `from meter.features.context import packet_direction` would cause error:
 AttributeError: module 'meter.features.context.packet_direction' has no attribute 'FORWARD'

the fixed import `from meter.features.context.packet_direction import PacketDirection` works fine for me.